### PR TITLE
Added failed urls to CRITICAL

### DIFF
--- a/check_multi_url/__init__.py
+++ b/check_multi_url/__init__.py
@@ -120,6 +120,11 @@ class CheckRunner():
                 self.mco.logger.debug(urltest['info'])
             if urltest['check_ok']:
                 self.mco.runfile['checks_ok'] += 1
+            else:
+                if self.info == '':
+                    self.info = "Failed: %s" % (urltest['url'])
+                else:
+                    self.info += ", %s" % (urltest['url'])
         del self.results          # cleanup
         self.mco.logger.info(self.mco.runfile)
 


### PR DESCRIPTION
This adds the failed urls to the output to see it in Icinga2 or Nagios.